### PR TITLE
Notification fix, play/pause fix

### DIFF
--- a/src/net/sourceforge/subsonic/androidapp/domain/PlayerState.java
+++ b/src/net/sourceforge/subsonic/androidapp/domain/PlayerState.java
@@ -18,17 +18,29 @@
  */
 package net.sourceforge.subsonic.androidapp.domain;
 
+import android.media.RemoteControlClient;
+
 /**
  * @author Sindre Mehus
  * @version $Id$
  */
 public enum PlayerState {
-    IDLE,
-    DOWNLOADING,
-    PREPARING,
-    PREPARED,
-    STARTED,
-    STOPPED,
-    PAUSED,
-    COMPLETED
+	IDLE(RemoteControlClient.PLAYSTATE_STOPPED),
+    DOWNLOADING(RemoteControlClient.PLAYSTATE_BUFFERING),
+    PREPARING(RemoteControlClient.PLAYSTATE_BUFFERING),
+    PREPARED(RemoteControlClient.PLAYSTATE_STOPPED),
+    STARTED(RemoteControlClient.PLAYSTATE_PLAYING),
+    STOPPED(RemoteControlClient.PLAYSTATE_STOPPED),
+    PAUSED(RemoteControlClient.PLAYSTATE_PAUSED),
+    COMPLETED(RemoteControlClient.PLAYSTATE_STOPPED);
+    
+    private final int mRemoteControlClientPlayState;
+    
+    private PlayerState(int playState) {
+    	mRemoteControlClientPlayState = playState;
+    }
+    
+    public int getRemoteControlClientPlayState() {
+    	return mRemoteControlClientPlayState;
+    }
 }

--- a/src/net/sourceforge/subsonic/androidapp/domain/PlayerState.java
+++ b/src/net/sourceforge/subsonic/androidapp/domain/PlayerState.java
@@ -18,29 +18,17 @@
  */
 package net.sourceforge.subsonic.androidapp.domain;
 
-import android.media.RemoteControlClient;
-
 /**
  * @author Sindre Mehus
  * @version $Id$
  */
 public enum PlayerState {
-	IDLE(RemoteControlClient.PLAYSTATE_STOPPED),
-    DOWNLOADING(RemoteControlClient.PLAYSTATE_BUFFERING),
-    PREPARING(RemoteControlClient.PLAYSTATE_BUFFERING),
-    PREPARED(RemoteControlClient.PLAYSTATE_STOPPED),
-    STARTED(RemoteControlClient.PLAYSTATE_PLAYING),
-    STOPPED(RemoteControlClient.PLAYSTATE_STOPPED),
-    PAUSED(RemoteControlClient.PLAYSTATE_PAUSED),
-    COMPLETED(RemoteControlClient.PLAYSTATE_STOPPED);
-    
-    private final int mRemoteControlClientPlayState;
-    
-    private PlayerState(int playState) {
-    	mRemoteControlClientPlayState = playState;
-    }
-    
-    public int getRemoteControlClientPlayState() {
-    	return mRemoteControlClientPlayState;
-    }
+    IDLE,
+    DOWNLOADING,
+    PREPARING,
+    PREPARED,
+    STARTED,
+    STOPPED,
+    PAUSED,
+    COMPLETED
 }

--- a/src/net/sourceforge/subsonic/androidapp/service/DownloadServiceImpl.java
+++ b/src/net/sourceforge/subsonic/androidapp/service/DownloadServiceImpl.java
@@ -760,7 +760,19 @@ public class DownloadServiceImpl extends Service implements DownloadService {
         		RemoteControlHelper.registerRemoteControlClient(audioManager, remoteControlClientCompat);
         	}
 
-        	remoteControlClientCompat.setPlaybackState(playerState.getRemoteControlClientPlayState());
+        	switch (playerState)
+        	{
+        	case STARTED:
+        		remoteControlClientCompat.setPlaybackState(RemoteControlClient.PLAYSTATE_PLAYING);
+        		break;
+        	case PAUSED:
+        		remoteControlClientCompat.setPlaybackState(RemoteControlClient.PLAYSTATE_PAUSED);
+        		break;
+        	case IDLE:
+        	case STOPPED:
+        		remoteControlClientCompat.setPlaybackState(RemoteControlClient.PLAYSTATE_STOPPED);
+        		break;
+        	}	
 
         	remoteControlClientCompat.setTransportControlFlags(
         			RemoteControlClient.FLAG_KEY_MEDIA_PLAY |

--- a/src/net/sourceforge/subsonic/androidapp/service/DownloadServiceImpl.java
+++ b/src/net/sourceforge/subsonic/androidapp/service/DownloadServiceImpl.java
@@ -760,19 +760,7 @@ public class DownloadServiceImpl extends Service implements DownloadService {
         		RemoteControlHelper.registerRemoteControlClient(audioManager, remoteControlClientCompat);
         	}
 
-        	switch (playerState)
-        	{
-        	case STARTED:
-        		remoteControlClientCompat.setPlaybackState(RemoteControlClient.PLAYSTATE_PLAYING);
-        		break;
-        	case PAUSED:
-        		remoteControlClientCompat.setPlaybackState(RemoteControlClient.PLAYSTATE_PAUSED);
-        		break;
-        	case IDLE:
-        	case STOPPED:
-        		remoteControlClientCompat.setPlaybackState(RemoteControlClient.PLAYSTATE_STOPPED);
-        		break;
-        	}	
+        	remoteControlClientCompat.setPlaybackState(playerState.getRemoteControlClientPlayState());
 
         	remoteControlClientCompat.setTransportControlFlags(
         			RemoteControlClient.FLAG_KEY_MEDIA_PLAY |
@@ -800,6 +788,7 @@ public class DownloadServiceImpl extends Service implements DownloadService {
     					remoteControlClientCompat
     							.editMetadata(true)
     							.putString(MediaMetadataRetriever.METADATA_KEY_TITLE, title)
+    							.putString(MediaMetadataRetriever.METADATA_KEY_ARTIST, currentSong.getArtist())
     							.putString(MediaMetadataRetriever.METADATA_KEY_ALBUM, album)
     							.putLong(MediaMetadataRetriever.METADATA_KEY_DURATION, duration)
     							.putBitmap(RemoteControlClientCompat.MetadataEditorCompat.METADATA_KEY_ARTWORK, bitmap)
@@ -875,7 +864,7 @@ public class DownloadServiceImpl extends Service implements DownloadService {
 		            	mp.start();
 		                setPlayerState(STARTED);
 		            } else {
-		                setPlayerState(PAUSED);
+		                setPlayerState(STOPPED);
 		            }
 		            
 		            lifecycleSupport.serializeDownloadQueue();

--- a/src/net/sourceforge/subsonic/androidapp/service/DownloadServiceLifecycleSupport.java
+++ b/src/net/sourceforge/subsonic/androidapp/service/DownloadServiceLifecycleSupport.java
@@ -200,6 +200,8 @@ public class DownloadServiceLifecycleSupport {
 
         // Work-around: Serialize again, as the restore() method creates a serialization without current playing info.
         serializeDownloadQueue();
+        
+        downloadService.setPlayerState(PlayerState.STOPPED);
     }
 
     private void handleKeyEvent(KeyEvent event) {
@@ -209,6 +211,8 @@ public class DownloadServiceLifecycleSupport {
 
         switch (event.getKeyCode()) {
             case KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE:
+            case KeyEvent.KEYCODE_MEDIA_PLAY:
+            case KeyEvent.KEYCODE_MEDIA_PAUSE:
             case KeyEvent.KEYCODE_HEADSETHOOK:
             	downloadService.togglePlayPause();
                 break;


### PR DESCRIPTION
I believe what's happening is that for whatever reason the download service gets restarted.  When it does, it initializes the play state to paused.  I actually have two fixes in the pull request I'm sending you...they're probably redundant.  I hadn't finished testing with one vs the other, but with both it didn't pop up at all today. But it sounds like one of them removes behavior you intended...if you intend to have the notification pop up right away at launch.  Personally I prefer it not to do so, but that's fine if you intended to do it that way.  I believe the change in net.sourceforge.subsonic.androidapp.service.DownloadServiceLifecycleSupport.deserializeDownloadQueue() on its own would do the job if you want to preserve the functionality.  The change in net.sourceforge.subsonic.androidapp.service.DownloadServiceImpl.doPlay(DownloadFile, int, boolean) should also do the job, but it means the notification does not pop up until something starts playing.

Also in this change is a fix for the play/pause functionality not working with remotes that send the play command instead of play/pause.  And I added having the metadata for the remote controls send the artist as well (i realize you're adding it to the title).  I was also trying to find a solution for the lock screen controls not working consistently (they often just stop showing up on my DNA), but I haven't figured that one out yet.
